### PR TITLE
Replaced deprecated function

### DIFF
--- a/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
@@ -54,7 +54,7 @@ GazeboRosSonar::~GazeboRosSonar()
 void GazeboRosSonar::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
 {
   // Get then name of the parent sensor
-  sensor_ = boost::shared_dynamic_cast<sensors::RaySensor>(_sensor);
+  sensor_ = boost::dynamic_pointer_cast<sensors::RaySensor>(_sensor);
   if (!sensor_)
   {
     gzthrow("GazeboRosSonar requires a Ray Sensor as its parent");


### PR DESCRIPTION
When compiling from source on Debian got errors about `boost::shared_static_cast()` function not being member of boost. Doing some research found that it is deprecated since boost 1.53 http://goo.gl/xh0NwP.

Replacing this function with `boost::dynamic_pointer_cast()` solved the compilation issue for me. 
