### PR TITLE
Fixes for compiling on Fedora

### DIFF
--- a/gazebo_rtt_plugin/include/gazebo_rtt_plugin/gazebo_rtt_plugin.h
+++ b/gazebo_rtt_plugin/include/gazebo_rtt_plugin/gazebo_rtt_plugin.h
@@ -29,9 +29,9 @@
 #ifndef GAZEBO_RTT_PLUGIN_GAZEBO_RTT_PLUGIN_H
 #define GAZEBO_RTT_PLUGIN_GAZEBO_RTT_PLUGIN_H
 
-#include <gazebo.hh>
-#include <physics/physics.hh>
-#include <common/common.hh>
+#include <gazebo/gazebo.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/common/common.hh>
 
 #include <rtt/TaskContext.hpp>
 

--- a/gazebo_rtt_plugin/package.xml
+++ b/gazebo_rtt_plugin/package.xml
@@ -17,8 +17,10 @@
   <!-- Dependencies needed to compile this package. -->
   <build_depend>gazebo</build_depend>
   <build_depend>hector_gazebo_plugins</build_depend>
+  <build_depend>rtt</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>rtt</run_depend>
 
 </package>


### PR DESCRIPTION
The missing rtt dependency is likely affecting Ubuntu debs as well, but doesn't cause a compile failure (which is odd).

The Gazebo include path is all that is needed to make your Gazebo plugin compatible with the Gazebo 2.2 API, and should be compatible with the current Ubuntu release, 1.9.

Thanks,

--scott
