### PR TITLE
fixed NaN return values of the attitude in the imu message

### DIFF
--- a/hector_gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -261,8 +261,8 @@ void GazeboRosIMU::Update()
   double normalization_constant = (gravity_body + accelModel.getCurrentError()).GetLength() * gravity_body.GetLength();
   double cos_alpha = (gravity_body + accelModel.getCurrentError()).Dot(gravity_body)/normalization_constant;
   math::Vector3 normal_vector(gravity_body.Cross(accelModel.getCurrentError()));
-  normal_vector *= sqrt((1 - cos_alpha)/2)/normalization_constant;
-  math::Quaternion attitudeError(sqrt((1 + cos_alpha)/2), normal_vector.x, normal_vector.y, normal_vector.z);
+  normal_vector *= sqrt(std::abs((1 - cos_alpha)/2))/normalization_constant;
+  math::Quaternion attitudeError(sqrt(std::abs((1 + cos_alpha)/2)), normal_vector.x, normal_vector.y, normal_vector.z);
   math::Quaternion headingError(cos(headingModel.getCurrentError()/2),0,0,sin(headingModel.getCurrentError()/2));
   pose.rot = attitudeError * pose.rot * headingError;
 


### PR DESCRIPTION
(1 - cos_alpha) can be a negative value and leads to NaN in the attitude because of the square root
