### PR TITLE
hector_gazebo_plugins/hector_gazebo_ros_imu: interpret parameters xyzOffset and rpyOffset as pure mounting offsets and not as induced by accelerometer bias

### DIFF
--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_imu.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_imu.h
@@ -89,6 +89,9 @@ namespace gazebo
       std::string topic_;
       std::string bias_topic_;
 
+      /// \brief allow specifying constant xyz and rpy offsets
+      math::Pose offset_;
+
       /// \brief Sensor models
       SensorModel3 accelModel;
       SensorModel3 rateModel;


### PR DESCRIPTION
From #18:

> Obviously the SDF conversion assumes that all sensor plugins interpret the `<xyzOffset>` and `<rpyOffset>` parameters in the same way as an additional sensor link which is connected with a static joint to the real parent frame. I was not aware that this is a requirement. hector_gazebo_ros_imu interpreted the roll and pitch part of `<rpyOffset>` as an orientation offset caused by a (small) accelerometer bias.

This patch completely removes the bias error on the orientation output in the Imu message and the orientation quaternion in the bias message is set to zero.
