### PR TITLE
hector_gazebo_plugins/gazebo_ros_force_based_move:  Added timeout for…

### DIFF
--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
@@ -47,12 +47,12 @@ namespace gazebo {
 
   class GazeboRosForceBasedMove : public ModelPlugin {
 
-    public: 
+    public:
       GazeboRosForceBasedMove();
       ~GazeboRosForceBasedMove();
       void Load(physics::ModelPtr parent, sdf::ElementPtr sdf);
 
-    protected: 
+    protected:
       virtual void UpdateChild();
       virtual void FiniChild();
 
@@ -87,6 +87,7 @@ namespace gazebo {
       std::string odometry_frame_;
       std::string robot_base_frame_;
       double odometry_rate_;
+      double cmd_vel_time_out_;
       bool publish_odometry_tf_;
 
       // Custom Callback Queue
@@ -96,6 +97,7 @@ namespace gazebo {
 
       // command velocity callback
       void cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg);
+      common::Time last_cmd_vel_time_;
 
       double x_;
       double y_;
@@ -103,7 +105,7 @@ namespace gazebo {
       bool alive_;
       common::Time last_odom_publish_time_;
       math::Pose last_odom_pose_;
-      
+
       double torque_yaw_velocity_p_gain_;
       double force_x_velocity_p_gain_;
       double force_y_velocity_p_gain_;

--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
@@ -114,4 +114,4 @@ namespace gazebo {
 
 }
 
-#endif /* end of include guard: GAZEBO_ROS_PLANAR_MOVE_HH */
+#endif /* end of include guard: GAZEBO_ROS_FORCE_BASED_MOVE_HH */

--- a/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
@@ -44,7 +44,7 @@ namespace gazebo
     robot_namespace_ = "";
     if (!sdf->HasElement("robotNamespace"))
     {
-      ROS_INFO("PlanarMovePlugin missing <robotNamespace>, "
+      ROS_INFO("ForceBasedMovePlugin missing <robotNamespace>, "
           "defaults to \"%s\"", robot_namespace_.c_str());
     }
     else
@@ -56,7 +56,7 @@ namespace gazebo
     command_topic_ = "cmd_vel";
     if (!sdf->HasElement("commandTopic"))
     {
-      ROS_WARN("PlanarMovePlugin (ns = %s) missing <commandTopic>, "
+      ROS_WARN("ForceBasedMovePlugin (ns = %s) missing <commandTopic>, "
           "defaults to \"%s\"",
           robot_namespace_.c_str(), command_topic_.c_str());
     }
@@ -68,7 +68,7 @@ namespace gazebo
     odometry_topic_ = "odom";
     if (!sdf->HasElement("odometryTopic"))
     {
-      ROS_WARN("PlanarMovePlugin (ns = %s) missing <odometryTopic>, "
+      ROS_WARN("ForceBasedMovePlugin (ns = %s) missing <odometryTopic>, "
           "defaults to \"%s\"",
           robot_namespace_.c_str(), odometry_topic_.c_str());
     }
@@ -80,7 +80,7 @@ namespace gazebo
     odometry_frame_ = "odom";
     if (!sdf->HasElement("odometryFrame"))
     {
-      ROS_WARN("PlanarMovePlugin (ns = %s) missing <odometryFrame>, "
+      ROS_WARN("ForceBasedMovePlugin (ns = %s) missing <odometryFrame>, "
           "defaults to \"%s\"",
           robot_namespace_.c_str(), odometry_frame_.c_str());
     }
@@ -110,7 +110,7 @@ namespace gazebo
     robot_base_frame_ = "base_footprint";
     if (!sdf->HasElement("robotBaseFrame"))
     {
-      ROS_WARN("PlanarMovePlugin (ns = %s) missing <robotBaseFrame>, "
+      ROS_WARN("ForceBasedMovePlugin (ns = %s) missing <robotBaseFrame>, "
           "defaults to \"%s\"",
           robot_namespace_.c_str(), robot_base_frame_.c_str());
     }
@@ -126,7 +126,7 @@ namespace gazebo
     odometry_rate_ = 20.0;
     if (!sdf->HasElement("odometryRate"))
     {
-      ROS_WARN("PlanarMovePlugin (ns = %s) missing <odometryRate>, "
+      ROS_WARN("ForceBasedMovePlugin (ns = %s) missing <odometryRate>, "
           "defaults to %f",
           robot_namespace_.c_str(), odometry_rate_);
     }
@@ -138,7 +138,7 @@ namespace gazebo
     cmd_vel_time_out_ = 0.25;
     if (!sdf->HasElement("cmdVelTimeOut"))
     {
-      ROS_WARN("PlanarMovePlugin (ns = %s) missing <cmdVelTimeOut>, "
+      ROS_WARN("ForceBasedMovePlugin (ns = %s) missing <cmdVelTimeOut>, "
           "defaults to %f",
           robot_namespace_.c_str(), cmd_vel_time_out_);
     }
@@ -149,7 +149,7 @@ namespace gazebo
 
     this->publish_odometry_tf_ = true;
     if (!sdf->HasElement("publishOdometryTf")) {
-      ROS_WARN("PlanarMovePlugin Plugin (ns = %s) missing <publishOdometryTf>, defaults to %s",
+      ROS_WARN("ForceBasedMovePlugin Plugin (ns = %s) missing <publishOdometryTf>, defaults to %s",
                this->robot_namespace_.c_str(), this->publish_odometry_tf_ ? "true" : "false");
     } else {
       this->publish_odometry_tf_ = sdf->GetElement("publishOdometryTf")->Get<bool>();
@@ -167,7 +167,7 @@ namespace gazebo
     // Ensure that ROS has been initialized and subscribe to cmd_vel
     if (!ros::isInitialized())
     {
-      ROS_FATAL_STREAM("PlanarMovePlugin (ns = " << robot_namespace_
+      ROS_FATAL_STREAM("ForceBasedMovePlugin (ns = " << robot_namespace_
         << "). A ROS node for Gazebo has not been initialized, "
         << "unable to load plugin. Load the Gazebo system plugin "
         << "'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
@@ -175,7 +175,7 @@ namespace gazebo
     }
     rosnode_.reset(new ros::NodeHandle(robot_namespace_));
 
-    ROS_DEBUG("OCPlugin (%s) has started!",
+    ROS_DEBUG("ForceBasedMovePlugin (%s) has started!",
         robot_namespace_.c_str());
 
     tf_prefix_ = tf::getPrefixParam(*rosnode_);

--- a/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
@@ -25,7 +25,7 @@
 
 #include <hector_gazebo_plugins/gazebo_ros_force_based_move.h>
 
-namespace gazebo 
+namespace gazebo
 {
 
   GazeboRosForceBasedMove::GazeboRosForceBasedMove() {}
@@ -34,7 +34,7 @@ namespace gazebo
 
   // Load the controller
   void GazeboRosForceBasedMove::Load(physics::ModelPtr parent,
-      sdf::ElementPtr sdf) 
+      sdf::ElementPtr sdf)
   {
 
     parent_ = parent;
@@ -42,58 +42,58 @@ namespace gazebo
     /* Parse parameters */
 
     robot_namespace_ = "";
-    if (!sdf->HasElement("robotNamespace")) 
+    if (!sdf->HasElement("robotNamespace"))
     {
       ROS_INFO("PlanarMovePlugin missing <robotNamespace>, "
           "defaults to \"%s\"", robot_namespace_.c_str());
     }
-    else 
+    else
     {
-      robot_namespace_ = 
+      robot_namespace_ =
         sdf->GetElement("robotNamespace")->Get<std::string>();
     }
 
     command_topic_ = "cmd_vel";
-    if (!sdf->HasElement("commandTopic")) 
+    if (!sdf->HasElement("commandTopic"))
     {
       ROS_WARN("PlanarMovePlugin (ns = %s) missing <commandTopic>, "
-          "defaults to \"%s\"", 
+          "defaults to \"%s\"",
           robot_namespace_.c_str(), command_topic_.c_str());
-    } 
-    else 
+    }
+    else
     {
       command_topic_ = sdf->GetElement("commandTopic")->Get<std::string>();
     }
 
     odometry_topic_ = "odom";
-    if (!sdf->HasElement("odometryTopic")) 
+    if (!sdf->HasElement("odometryTopic"))
     {
       ROS_WARN("PlanarMovePlugin (ns = %s) missing <odometryTopic>, "
-          "defaults to \"%s\"", 
+          "defaults to \"%s\"",
           robot_namespace_.c_str(), odometry_topic_.c_str());
-    } 
-    else 
+    }
+    else
     {
       odometry_topic_ = sdf->GetElement("odometryTopic")->Get<std::string>();
     }
 
     odometry_frame_ = "odom";
-    if (!sdf->HasElement("odometryFrame")) 
+    if (!sdf->HasElement("odometryFrame"))
     {
       ROS_WARN("PlanarMovePlugin (ns = %s) missing <odometryFrame>, "
           "defaults to \"%s\"",
           robot_namespace_.c_str(), odometry_frame_.c_str());
     }
-    else 
+    else
     {
       odometry_frame_ = sdf->GetElement("odometryFrame")->Get<std::string>();
     }
-    
-    
+
+
     torque_yaw_velocity_p_gain_ = 100.0;
     force_x_velocity_p_gain_ = 10000.0;
     force_y_velocity_p_gain_ = 10000.0;
-    
+
     if (sdf->HasElement("yaw_velocity_p_gain"))
       (sdf->GetElement("yaw_velocity_p_gain")->GetValue()->Get(torque_yaw_velocity_p_gain_));
 
@@ -102,19 +102,19 @@ namespace gazebo
 
     if (sdf->HasElement("y_velocity_p_gain"))
       (sdf->GetElement("y_velocity_p_gain")->GetValue()->Get(force_y_velocity_p_gain_));
-      
+
     ROS_INFO_STREAM("ForceBasedMove using gains: yaw: " << torque_yaw_velocity_p_gain_ <<
                                                  " x: " << force_x_velocity_p_gain_ <<
                                                  " y: " << force_y_velocity_p_gain_ << "\n");
 
     robot_base_frame_ = "base_footprint";
-    if (!sdf->HasElement("robotBaseFrame")) 
+    if (!sdf->HasElement("robotBaseFrame"))
     {
       ROS_WARN("PlanarMovePlugin (ns = %s) missing <robotBaseFrame>, "
           "defaults to \"%s\"",
           robot_namespace_.c_str(), robot_base_frame_.c_str());
-    } 
-    else 
+    }
+    else
     {
       robot_base_frame_ = sdf->GetElement("robotBaseFrame")->Get<std::string>();
     }
@@ -124,16 +124,28 @@ namespace gazebo
     this->link_ = parent->GetLink(robot_base_frame_);
 
     odometry_rate_ = 20.0;
-    if (!sdf->HasElement("odometryRate")) 
+    if (!sdf->HasElement("odometryRate"))
     {
       ROS_WARN("PlanarMovePlugin (ns = %s) missing <odometryRate>, "
           "defaults to %f",
           robot_namespace_.c_str(), odometry_rate_);
-    } 
-    else 
+    }
+    else
     {
       odometry_rate_ = sdf->GetElement("odometryRate")->Get<double>();
-    } 
+    }
+
+    cmd_vel_time_out_ = 0.25;
+    if (!sdf->HasElement("cmdVelTimeOut"))
+    {
+      ROS_WARN("PlanarMovePlugin (ns = %s) missing <cmdVelTimeOut>, "
+          "defaults to %f",
+          robot_namespace_.c_str(), cmd_vel_time_out_);
+    }
+    else
+    {
+      cmd_vel_time_out_ = sdf->GetElement("cmdVelTimeOut")->Get<double>();
+    }
 
     this->publish_odometry_tf_ = true;
     if (!sdf->HasElement("publishOdometryTf")) {
@@ -142,7 +154,7 @@ namespace gazebo
     } else {
       this->publish_odometry_tf_ = sdf->GetElement("publishOdometryTf")->Get<bool>();
     }
- 
+
     last_odom_publish_time_ = parent_->GetWorld()->GetSimTime();
     last_odom_pose_ = parent_->GetWorldPose();
     x_ = 0;
@@ -153,7 +165,7 @@ namespace gazebo
     odom_transform_.setIdentity();
 
     // Ensure that ROS has been initialized and subscribe to cmd_vel
-    if (!ros::isInitialized()) 
+    if (!ros::isInitialized())
     {
       ROS_FATAL_STREAM("PlanarMovePlugin (ns = " << robot_namespace_
         << "). A ROS node for Gazebo has not been initialized, "
@@ -163,7 +175,7 @@ namespace gazebo
     }
     rosnode_.reset(new ros::NodeHandle(robot_namespace_));
 
-    ROS_DEBUG("OCPlugin (%s) has started!", 
+    ROS_DEBUG("OCPlugin (%s) has started!",
         robot_namespace_.c_str());
 
     tf_prefix_ = tf::getPrefixParam(*rosnode_);
@@ -181,11 +193,11 @@ namespace gazebo
     odometry_pub_ = rosnode_->advertise<nav_msgs::Odometry>(odometry_topic_, 1);
 
     // start custom queue for diff drive
-    callback_queue_thread_ = 
+    callback_queue_thread_ =
       boost::thread(boost::bind(&GazeboRosForceBasedMove::QueueThread, this));
 
     // listen to the update event (broadcast every simulation iteration)
-    update_connection_ = 
+    update_connection_ =
       event::Events::ConnectWorldUpdateBegin(
           boost::bind(&GazeboRosForceBasedMove::UpdateChild, this));
 
@@ -198,6 +210,12 @@ namespace gazebo
     math::Pose pose = parent_->GetWorldPose();
 
     math::Vector3 angular_vel = parent_->GetWorldAngularVel();
+
+    if ((parent_->GetWorld()->GetSimTime() - last_cmd_vel_time_) > cmd_vel_time_out_) {
+      x_ = 0.0;
+      y_ = 0.0;
+      rot_ = 0.0;
+    }
 
     double error = angular_vel.z - rot_;
 
@@ -219,7 +237,7 @@ namespace gazebo
 
     if (odometry_rate_ > 0.0) {
       common::Time current_time = parent_->GetWorld()->GetSimTime();
-      double seconds_since_last_update = 
+      double seconds_since_last_update =
         (current_time - last_odom_publish_time_).Double();
       if (seconds_since_last_update > (1.0 / odometry_rate_)) {
         publishOdometry(seconds_since_last_update);
@@ -238,18 +256,19 @@ namespace gazebo
   }
 
   void GazeboRosForceBasedMove::cmdVelCallback(
-      const geometry_msgs::Twist::ConstPtr& cmd_msg) 
+      const geometry_msgs::Twist::ConstPtr& cmd_msg)
   {
     boost::mutex::scoped_lock scoped_lock(lock);
     x_ = cmd_msg->linear.x;
     y_ = cmd_msg->linear.y;
     rot_ = cmd_msg->angular.z;
+    last_cmd_vel_time_= parent_->GetWorld()->GetSimTime();
   }
 
   void GazeboRosForceBasedMove::QueueThread()
   {
     static const double timeout = 0.01;
-    while (alive_ && rosnode_->ok()) 
+    while (alive_ && rosnode_->ok())
     {
       queue_.callAvailable(ros::WallDuration(timeout));
     }
@@ -260,7 +279,7 @@ namespace gazebo
 
     ros::Time current_time = ros::Time::now();
     std::string odom_frame = tf::resolve(tf_prefix_, odometry_frame_);
-    std::string base_footprint_frame = 
+    std::string base_footprint_frame =
       tf::resolve(tf_prefix_, robot_base_frame_);
 
     math::Vector3 angular_vel = parent_->GetRelativeAngularVel();
@@ -281,13 +300,13 @@ namespace gazebo
           tf::StampedTransform(odom_transform_, current_time, odom_frame,
               base_footprint_frame));
     }
-    
+
     odom_.pose.covariance[0] = 0.001;
     odom_.pose.covariance[7] = 0.001;
     odom_.pose.covariance[14] = 1000000000000.0;
     odom_.pose.covariance[21] = 1000000000000.0;
     odom_.pose.covariance[28] = 1000000000000.0;
-    
+
     if (std::abs(angular_vel.z) < 0.0001) {
       odom_.pose.covariance[35] = 0.01;
     }else{
@@ -339,4 +358,3 @@ namespace gazebo
 
   GZ_REGISTER_MODEL_PLUGIN(GazeboRosForceBasedMove)
 }
-


### PR DESCRIPTION
… command velocity to stop the forces/torques.  Had issues when tele-operating a robot with this plugin where the robot would keep going.  The forces/torques kept acting since the teleop node quickly stopped publishing velocity.  Once the plugin times out, the desired velocities are set to zero causing opposite  forces/torques which stops the robot.
