### PR TITLE
Support Indigo + gazebo7

### DIFF
--- a/hector_gazebo_plugins/src/diffdrive_plugin_6w.cpp
+++ b/hector_gazebo_plugins/src/diffdrive_plugin_6w.cpp
@@ -44,6 +44,8 @@
 #include <nav_msgs/Odometry.h>
 #include <boost/bind.hpp>
 
+#include <gazebo/gazebo_config.h>
+
 namespace gazebo {
 
 enum
@@ -228,6 +230,15 @@ void DiffDrivePlugin6W::Update()
     joints[MID_RIGHT]->SetVelocity(0, wheelSpeed[1] / (wheelDiam / 2.0));
     joints[REAR_RIGHT]->SetVelocity(0, wheelSpeed[1] / (wheelDiam / 2.0));
 
+#if (GAZEBO_MAJOR_VERSION > 4)
+    joints[FRONT_LEFT]->SetParam("fmax", 0, torque);
+    joints[MID_LEFT]->SetParam("fmax", 0, torque);
+    joints[REAR_LEFT]->SetParam("fmax", 0, torque);
+
+    joints[FRONT_RIGHT]->SetParam("fmax", 0, torque);
+    joints[MID_RIGHT]->SetParam("fmax", 0, torque);
+    joints[REAR_RIGHT]->SetParam("fmax", 0, torque);
+#else
     joints[FRONT_LEFT]->SetMaxForce(0, torque);
     joints[MID_LEFT]->SetMaxForce(0, torque);
     joints[REAR_LEFT]->SetMaxForce(0, torque);
@@ -235,6 +246,7 @@ void DiffDrivePlugin6W::Update()
     joints[FRONT_RIGHT]->SetMaxForce(0, torque);
     joints[MID_RIGHT]->SetMaxForce(0, torque);
     joints[REAR_RIGHT]->SetMaxForce(0, torque);
+#endif
   }
 
   //publish_odometry();

--- a/hector_gazebo_plugins/src/diffdrive_plugin_multi_wheel.cpp
+++ b/hector_gazebo_plugins/src/diffdrive_plugin_multi_wheel.cpp
@@ -91,6 +91,8 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 
+#include <gazebo/gazebo_config.h>
+
 namespace gazebo {
 
   enum {
@@ -247,7 +249,11 @@ namespace gazebo {
                    this->robot_namespace_.c_str(), joint_names_[side][i].c_str());
           gzthrow(error);
         }
+#if (GAZEBO_MAJOR_VERSION > 4)
+        joints_[side][i]->SetParam("fmax", 0, torque);
+#else
         joints_[side][i]->SetMaxForce(0, torque);
+#endif
       }
     }
 

--- a/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
@@ -160,7 +160,11 @@ void GazeboRosSonar::Update()
   int num_ranges = sensor_->GetLaserShape()->GetSampleCount() * sensor_->GetLaserShape()->GetVerticalSampleCount();
 #endif
   for(int i = 0; i < num_ranges; ++i) {
+#if (GAZEBO_MAJOR_VERSION > 6)
     double ray = sensor_->LaserShape()->GetRange(i);
+#else
+    double ray = sensor_->GetLaserShape()->GetRange(i);
+#endif
     if (ray < range_.range) range_.range = ray;
   }
 

--- a/hector_gazebo_plugins/src/servo_plugin.cpp
+++ b/hector_gazebo_plugins/src/servo_plugin.cpp
@@ -29,6 +29,7 @@
 #include <hector_gazebo_plugins/servo_plugin.h>
 #include <gazebo/common/Events.hh>
 #include <gazebo/physics/physics.hh>
+#include <gazebo/gazebo_config.h>
 
 #include <sensor_msgs/JointState.h>
 
@@ -200,6 +201,15 @@ void ServoPlugin::Update()
       }
     }
 
+#if (GAZEBO_MAJOR_VERSION > 4)
+    servo[FIRST].joint->SetParam("fmax", 0, maximumTorque);
+    if (countOfServos > 1) {
+      servo[SECOND].joint->SetParam("fmax", 0, maximumTorque);
+      if (countOfServos > 2) {
+        servo[THIRD].joint->SetParam("fmax", 0, maximumTorque);
+      }
+    }
+#else
     servo[FIRST].joint->SetMaxForce(0, maximumTorque);
     if (countOfServos > 1) {
       servo[SECOND].joint->SetMaxForce(0, maximumTorque);
@@ -207,7 +217,17 @@ void ServoPlugin::Update()
         servo[THIRD].joint->SetMaxForce(0, maximumTorque);
       }
     }
+#endif
   } else {
+#if (GAZEBO_MAJOR_VERSION > 4)
+    servo[FIRST].joint->SetParam("fmax", 0, 0.0);
+    if (countOfServos > 1) {
+      servo[SECOND].joint->SetParam("fmax", 0, 0.0);
+      if (countOfServos > 2) {
+        servo[THIRD].joint->SetParam("fmax", 0, 0.0);
+      }
+    }
+#else
     servo[FIRST].joint->SetMaxForce(0, 0.0);
     if (countOfServos > 1) {
       servo[SECOND].joint->SetMaxForce(0, 0.0);
@@ -215,6 +235,7 @@ void ServoPlugin::Update()
         servo[THIRD].joint->SetMaxForce(0, 0.0);
       }
     }
+#endif
   }
 }
 

--- a/hector_gazebo_thermal_camera/src/gazebo_ros_thermal_camera.cpp
+++ b/hector_gazebo_thermal_camera/src/gazebo_ros_thermal_camera.cpp
@@ -57,6 +57,8 @@
 
 #include <sensor_msgs/image_encodings.h>
 
+#include <gazebo/gazebo_config.h>
+
 namespace gazebo
 {
 
@@ -105,7 +107,11 @@ void GazeboRosThermalCamera_<Base>::OnNewFrame(const unsigned char *_image,
   if (!this->initialized_ || this->height_ <=0 || this->width_ <=0)
     return;
 
+#if (GAZEBO_MAJOR_VERSION > 6)
+  this->sensor_update_time_ = this->parentSensor_->LastUpdateTime();
+#else
   this->sensor_update_time_ = this->parentSensor_->GetLastUpdateTime();
+#endif
 
   if (!this->parentSensor->IsActive())
   {


### PR DESCRIPTION
Adds `ifdefs` around gazebo7 API changes.

This should make it possible to use `ros-indigo-gazebo7-ros-pkgs`.
