### PR TITLE
Add movement support for holonomic robots

### DIFF
--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
@@ -59,7 +59,7 @@ namespace gazebo {
     private:
       void publishOdometry(double step_time);
 
-      tf::Transform getTransformForMotion(double linear_vel_x, double angular_vel, double timeSeconds) const;
+      tf::Transform getTransformForMotion(double linear_vel_x, double linear_vel_y, double angular_vel, double timeSeconds) const;
 
       physics::ModelPtr parent_;
       event::ConnectionPtr update_connection_;


### PR DESCRIPTION
The current plugin only supports differential motion in the X direction and does not publish odometry information in the Y. For holonomic robots, movement in both directions simultaneously is common.

This PR adds the ability for simultaneous X/Y motion and Y motion.
