### PR TITLE
reverse rotation in IMU linear acceleration calculation

### DIFF
--- a/hector_gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -260,7 +260,7 @@ void GazeboRosIMU::Update()
   // the result of GetRelativeLinearAccel() seems to be unreliable (sum of forces added during the current simulation step)?
   //accel = myBody->GetRelativeLinearAccel(); // get acceleration in body frame
   math::Vector3 temp = link->GetWorldLinearVel(); // get velocity in world frame
-  if (dt > 0.0) accel = rot.RotateVectorReverse((temp - velocity) / dt - gravity);
+  if (dt > 0.0) accel = rot.RotateVector((temp - velocity) / dt - gravity);
   velocity = temp;
 
   // calculate angular velocity from delta quaternion


### PR DESCRIPTION
I'm working with a Gazebo model in which the link to which I'm attaching a hector IMU is rotated to have Z down. In that situation, I find that the linear acceleration data from this plugin becomes pretty wrong. It seems to be that it's no longer in a body-fixed frame (e.g., with only diff-drive commands, I get non-zero Y accelerations depending on which direction the vehicle is pointing in the world).

After looking at the code with @scpeters, it seems that this rotation is going the wrong direction. At least, after reversing it as I've done here, I get sensible accel data irrespective of how I mount the IMU on the model and which direction the vehicle is oriented in the world.

I can appreciate that this is a pretty fundamental change and I'm not sure how to best go about testing it, but I'm happy to help.