### PR TITLE
updates for gazebo 9 for IMU

### DIFF
--- a/hector_gazebo_plugins/CMakeLists.txt
+++ b/hector_gazebo_plugins/CMakeLists.txt
@@ -62,36 +62,36 @@ catkin_package(
 ## Build ##
 ###########
 
-add_library(diffdrive_plugin_6w src/diffdrive_plugin_6w.cpp)
-target_link_libraries(diffdrive_plugin_6w ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_library(diffdrive_plugin_6w src/diffdrive_plugin_6w.cpp)
+# target_link_libraries(diffdrive_plugin_6w ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
-add_library(diffdrive_plugin_multi_wheel src/diffdrive_plugin_multi_wheel.cpp)
-target_link_libraries(diffdrive_plugin_multi_wheel ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_library(diffdrive_plugin_multi_wheel src/diffdrive_plugin_multi_wheel.cpp)
+# target_link_libraries(diffdrive_plugin_multi_wheel ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
-add_library(gazebo_ros_force_based_move src/gazebo_ros_force_based_move.cpp)
-target_link_libraries(gazebo_ros_force_based_move ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_library(gazebo_ros_force_based_move src/gazebo_ros_force_based_move.cpp)
+# target_link_libraries(gazebo_ros_force_based_move ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
-add_library(hector_gazebo_reset_plugin src/reset_plugin.cpp)
-target_link_libraries(hector_gazebo_reset_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_library(hector_gazebo_reset_plugin src/reset_plugin.cpp)
+# target_link_libraries(hector_gazebo_reset_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
 add_library(hector_gazebo_ros_imu src/gazebo_ros_imu.cpp)
 target_link_libraries(hector_gazebo_ros_imu ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(hector_gazebo_ros_imu ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
 
-add_library(hector_gazebo_ros_magnetic src/gazebo_ros_magnetic.cpp)
-target_link_libraries(hector_gazebo_ros_magnetic ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
-add_dependencies(hector_gazebo_ros_magnetic ${PROJECT_NAME}_gencfg)
+# add_library(hector_gazebo_ros_magnetic src/gazebo_ros_magnetic.cpp)
+# target_link_libraries(hector_gazebo_ros_magnetic ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_dependencies(hector_gazebo_ros_magnetic ${PROJECT_NAME}_gencfg)
 
-add_library(hector_gazebo_ros_gps src/gazebo_ros_gps.cpp)
-target_link_libraries(hector_gazebo_ros_gps ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
-add_dependencies(hector_gazebo_ros_gps ${PROJECT_NAME}_gencfg)
+# add_library(hector_gazebo_ros_gps src/gazebo_ros_gps.cpp)
+# target_link_libraries(hector_gazebo_ros_gps ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_dependencies(hector_gazebo_ros_gps ${PROJECT_NAME}_gencfg)
 
-add_library(hector_gazebo_ros_sonar src/gazebo_ros_sonar.cpp)
-target_link_libraries(hector_gazebo_ros_sonar ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
-add_dependencies(hector_gazebo_ros_sonar ${PROJECT_NAME}_gencfg)
+# add_library(hector_gazebo_ros_sonar src/gazebo_ros_sonar.cpp)
+# target_link_libraries(hector_gazebo_ros_sonar ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_dependencies(hector_gazebo_ros_sonar ${PROJECT_NAME}_gencfg)
 
-add_library(hector_servo_plugin src/servo_plugin.cpp)
-target_link_libraries(hector_servo_plugin ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
+# add_library(hector_servo_plugin src/servo_plugin.cpp)
+# target_link_libraries(hector_servo_plugin ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
 #############
 ## Install ##
@@ -107,15 +107,15 @@ install(DIRECTORY include/${PROJECT_NAME}/
 )
 
 install(TARGETS
-  diffdrive_plugin_6w
-  diffdrive_plugin_multi_wheel
-  gazebo_ros_force_based_move
-  hector_gazebo_reset_plugin
+  # diffdrive_plugin_6w
+  # diffdrive_plugin_multi_wheel
+  # gazebo_ros_force_based_move
+  # hector_gazebo_reset_plugin
   hector_gazebo_ros_imu
-  hector_gazebo_ros_magnetic
-  hector_gazebo_ros_gps
-  hector_gazebo_ros_sonar
-  hector_servo_plugin
+  # hector_gazebo_ros_magnetic
+  # hector_gazebo_ros_gps
+  # hector_gazebo_ros_sonar
+  # hector_servo_plugin
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_imu.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_imu.h
@@ -90,7 +90,7 @@ namespace gazebo
       std::string bias_topic_;
 
       /// \brief allow specifying constant xyz and rpy offsets
-      math::Pose offset_;
+      ignition::math::Pose3d offset_;
 
       /// \brief Sensor models
       SensorModel3 accelModel;
@@ -101,11 +101,11 @@ namespace gazebo
       boost::mutex lock;
 
       /// \brief save current body/physics state
-      math::Quaternion orientation;
-      math::Vector3 velocity;
-      math::Vector3 accel;
-      math::Vector3 rate;
-      math::Vector3 gravity;
+      ignition::math::Quaterniond orientation;
+      ignition::math::Vector3d velocity;
+      ignition::math::Vector3d accel;
+      ignition::math::Vector3d rate;
+      ignition::math::Vector3d gravity;
 
       /// \brief Gaussian noise generator
       double GaussianKernel(double mu,double sigma);

--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/sensor_model.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/sensor_model.h
@@ -30,7 +30,6 @@
 #define HECTOR_GAZEBO_PLUGINS_SENSOR_MODEL_H
 
 #include <sdf/sdf.hh>
-#include <gazebo/math/Vector3.hh>
 
 #include <hector_gazebo_plugins/SensorModelConfig.h>
 #include <numeric>
@@ -166,11 +165,12 @@ double SensorModel_<double>::update(double dt)
 }
 
 template <>
-math::Vector3 SensorModel_<math::Vector3>::update(double dt)
+ignition::math::Vector3d SensorModel_<ignition::math::Vector3d>::update(double dt)
+
 {
-  current_error_.x = SensorModelInternalUpdate(current_drift_.x, drift.x, drift_frequency.x, offset.x, gaussian_noise.x, dt);
-  current_error_.y = SensorModelInternalUpdate(current_drift_.y, drift.y, drift_frequency.y, offset.y, gaussian_noise.y, dt);
-  current_error_.z = SensorModelInternalUpdate(current_drift_.z, drift.z, drift_frequency.z, offset.z, gaussian_noise.z, dt);
+  current_error_.X(SensorModelInternalUpdate(current_drift_.X(), drift.X(), drift_frequency.X(), offset.X(), gaussian_noise.X(), dt));
+  current_error_.Y(SensorModelInternalUpdate(current_drift_.Y(), drift.Y(), drift_frequency.Y(), offset.Y(), gaussian_noise.Y(), dt));
+  current_error_.Z(SensorModelInternalUpdate(current_drift_.Z(), drift.Z(), drift_frequency.Z(), offset.Z(), gaussian_noise.Z(), dt));
   return current_error_;
 }
 
@@ -189,12 +189,12 @@ void SensorModel_<double>::reset()
 }
 
 template <>
-void SensorModel_<math::Vector3>::reset()
+void SensorModel_<ignition::math::Vector3d>::reset()
 {
-  current_drift_.x = SensorModelGaussianKernel(0.0, drift.x);
-  current_drift_.y = SensorModelGaussianKernel(0.0, drift.y);
-  current_drift_.z = SensorModelGaussianKernel(0.0, drift.z);
-  current_error_ = math::Vector3();
+  current_drift_.X(SensorModelGaussianKernel(0.0, drift.X()));
+  current_drift_.Y(SensorModelGaussianKernel(0.0, drift.Y()));
+  current_drift_.Z(SensorModelGaussianKernel(0.0, drift.Z()));
+  current_error_ = ignition::math::Vector3d();
 }
 
 template <typename T>
@@ -207,7 +207,7 @@ void SensorModel_<T>::reset(const T& value)
 namespace helpers {
   template <typename T> struct scalar_value { static double toDouble(const T &orig) { return orig; } };
   template <typename T> struct scalar_value<std::vector<T> > { static double toDouble(const std::vector<T> &orig) { return (double) std::accumulate(orig.begin(), orig.end()) / orig.size(); } };
-  template <> struct scalar_value<math::Vector3> { static double toDouble(const math::Vector3 &orig) { return (orig.x + orig.y + orig.z) / 3; } };
+  template <> struct scalar_value<ignition::math::Vector3d> { static double toDouble(const ignition::math::Vector3d &orig) { return (orig.X() + orig.Y() + orig.Z()) / 3; } };
 }
 
 template <typename T>
@@ -229,7 +229,7 @@ void SensorModel_<T>::dynamicReconfigureCallback(SensorModelConfig &config, uint
 }
 
 typedef SensorModel_<double> SensorModel;
-typedef SensorModel_<math::Vector3> SensorModel3;
+typedef SensorModel_<ignition::math::Vector3d> SensorModel3;
 
 }
 

--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/servo_plugin.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/servo_plugin.h
@@ -24,7 +24,7 @@
 
 #include <gazebo/common/Plugin.hh>
 #include <gazebo/common/Time.hh>
-#include <gazebo/math/Quaternion.hh>
+#include <ignition/math/Quaternion.hh>
 
 // ROS 
 #include <ros/ros.h>

--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/update_timer.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/update_timer.h
@@ -80,10 +80,11 @@ public:
 
   virtual void Disconnect(event::ConnectionPtr const& _c = event::ConnectionPtr())
   {
-    if (_c) update_event_.Disconnect(_c);
-
+    //if (_c) update_event_.Disconnect(_c);
+    if (_c) update_event_.Disconnect(_c->Id());
     if (update_connection_ && (!_c || --connection_count_ == 0)) {
-      event::Events::DisconnectWorldUpdateBegin(update_connection_);
+      // event::Events::DisconnectWorldUpdateBegin(update_connection_);
+      // not sure if that'll work?
       update_connection_.reset();
     }
   }
@@ -111,22 +112,22 @@ public:
 
   common::Time getTimeSinceLastUpdate() const {
     if (last_update_ == common::Time()) return common::Time();
-    return world_->GetSimTime() - last_update_;
+    return world_->SimTime() - last_update_;
   }
 
   virtual bool checkUpdate() const
   {
     double period = update_period_.Double();
-    double step = world_->GetPhysicsEngine()->GetMaxStepSize();
+    double step = world_->Physics()->GetMaxStepSize();
     if (period == 0) return true;
-    double fraction = fmod((world_->GetSimTime() - update_offset_).Double() + (step / 2.0), period);
+    double fraction = fmod((world_->SimTime() - update_offset_).Double() + (step / 2.0), period);
     return (fraction >= 0.0) && (fraction < step);
   }
 
   virtual bool update()
   {
     if (!checkUpdate()) return false;
-    last_update_ = world_->GetSimTime();
+    last_update_ = world_->SimTime();
     return true;
   }
 
@@ -148,7 +149,7 @@ protected:
       return false;
     }
     update_event_();
-    last_update_ = world_->GetSimTime();
+    last_update_ = world_->SimTime();
     return true;
   }
 

--- a/hector_gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -26,11 +26,13 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //=================================================================================================
 
+#define BOOST_VARIANT_USE_RELAXED_GET_BY_DEFAULT // remove boost_assert error
 #include <hector_gazebo_plugins/gazebo_ros_imu.h>
 #include <gazebo/common/Events.hh>
 #include <gazebo/physics/physics.hh>
 
 #include <ros/console.h>
+
 
 namespace gazebo
 {
@@ -129,26 +131,28 @@ void GazeboRosIMU::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   }
 
   if (_sdf->HasElement("xyzOffset")) {
-    this->offset_.pos = _sdf->Get<math::Vector3>("xyzOffset");
+    this->offset_.Pos() = _sdf->Get<ignition::math::Vector3d>("xyzOffset");
   } else {
     ROS_INFO("imu plugin missing <xyzOffset>, defaults to 0s");
-    this->offset_.pos = math::Vector3(0, 0, 0);
+    this->offset_.Pos() = ignition::math::Vector3d(0, 0, 0);
   }
 
   if (_sdf->HasElement("rpyOffset")) {
-    this->offset_.rot = _sdf->Get<math::Vector3>("rpyOffset");
+    ignition::math::Quaterniond q(_sdf->Get<ignition::math::Vector3d>("rpyOffset")); 
+    this->offset_.Rot() = q;
   } else {
     ROS_INFO("imu plugin missing <rpyOffset>, defaults to 0s");
-    this->offset_.rot = math::Vector3(0, 0, 0);
+    ignition::math::Quaterniond q(ignition::math::Vector3d(0, 0, 0));
+    this->offset_.Rot() = q;
   }
 
   // fill in constant covariance matrix
-  imuMsg.angular_velocity_covariance[0] = rateModel.gaussian_noise.x*rateModel.gaussian_noise.x;
-  imuMsg.angular_velocity_covariance[4] = rateModel.gaussian_noise.y*rateModel.gaussian_noise.y;
-  imuMsg.angular_velocity_covariance[8] = rateModel.gaussian_noise.z*rateModel.gaussian_noise.z;
-  imuMsg.linear_acceleration_covariance[0] = accelModel.gaussian_noise.x*accelModel.gaussian_noise.x;
-  imuMsg.linear_acceleration_covariance[4] = accelModel.gaussian_noise.y*accelModel.gaussian_noise.y;
-  imuMsg.linear_acceleration_covariance[8] = accelModel.gaussian_noise.z*accelModel.gaussian_noise.z;
+  imuMsg.angular_velocity_covariance[0] = rateModel.gaussian_noise.X()*rateModel.gaussian_noise.X();
+  imuMsg.angular_velocity_covariance[4] = rateModel.gaussian_noise.Y()*rateModel.gaussian_noise.Y();
+  imuMsg.angular_velocity_covariance[8] = rateModel.gaussian_noise.Z()*rateModel.gaussian_noise.Z();
+  imuMsg.linear_acceleration_covariance[0] = accelModel.gaussian_noise.X()*accelModel.gaussian_noise.X();
+  imuMsg.linear_acceleration_covariance[4] = accelModel.gaussian_noise.Y()*accelModel.gaussian_noise.Y();
+  imuMsg.linear_acceleration_covariance[8] = accelModel.gaussian_noise.Z()*accelModel.gaussian_noise.Z();
 
   // Make sure the ROS node for Gazebo has already been initialized
   if (!ros::isInitialized())
@@ -203,7 +207,7 @@ void GazeboRosIMU::Reset()
 {
   updateTimer.Reset();
 
-  orientation = math::Quaternion();
+  orientation = ignition::math::Quaterniond();
   velocity = 0.0;
   accel = 0.0;
 
@@ -218,21 +222,21 @@ bool GazeboRosIMU::ServiceCallback(std_srvs::Empty::Request &req,
                                         std_srvs::Empty::Response &res)
 {
   boost::mutex::scoped_lock scoped_lock(lock);
-  rateModel.reset(math::Vector3(0.0, 0.0, 0.0));
+  rateModel.reset(ignition::math::Vector3d(0.0, 0.0, 0.0));
   return true;
 }
 
 bool GazeboRosIMU::SetAccelBiasCallback(hector_gazebo_plugins::SetBias::Request &req, hector_gazebo_plugins::SetBias::Response &res)
 {
   boost::mutex::scoped_lock scoped_lock(lock);
-  accelModel.reset(math::Vector3(req.bias.x, req.bias.y, req.bias.z));
+  accelModel.reset(ignition::math::Vector3d(req.bias.x, req.bias.y, req.bias.z));
   return true;
 }
 
 bool GazeboRosIMU::SetRateBiasCallback(hector_gazebo_plugins::SetBias::Request &req, hector_gazebo_plugins::SetBias::Response &res)
 {
   boost::mutex::scoped_lock scoped_lock(lock);
-  rateModel.reset(math::Vector3(req.bias.x, req.bias.y, req.bias.z));
+  rateModel.reset(ignition::math::Vector3d(req.bias.x, req.bias.y, req.bias.z));
   return true;
 }
 
@@ -241,36 +245,37 @@ bool GazeboRosIMU::SetRateBiasCallback(hector_gazebo_plugins::SetBias::Request &
 void GazeboRosIMU::Update()
 {
   // Get Time Difference dt
-  common::Time cur_time = world->GetSimTime();
+  common::Time cur_time = world->SimTime();
   double dt = updateTimer.getTimeSinceLastUpdate().Double();
   boost::mutex::scoped_lock scoped_lock(lock);
 
   // Get Pose/Orientation
-  math::Pose pose = link->GetWorldPose();
+  ignition::math::Pose3d pose = link->WorldCoGPose(); // might be wrong, maybe WorldInertialPose?
   // math::Vector3 pos = pose.pos + this->offset_.pos;
-  math::Quaternion rot = this->offset_.rot * pose.rot;
+  ignition::math::Quaterniond rot = this->offset_.Rot() * pose.Rot();
   rot.Normalize();
 
   // get Gravity
-  gravity = world->GetPhysicsEngine()->GetGravity();
-  double gravity_length = gravity.GetLength();
-  ROS_DEBUG_NAMED("gazebo_ros_imu", "gravity_world = [%g %g %g]", gravity.x, gravity.y, gravity.z);
+  gravity = world->Gravity();
+  // gravity = world->Physics()->GetGravity();
+  double gravity_length = gravity.Length();
+  ROS_DEBUG_NAMED("gazebo_ros_imu", "gravity_world = [%g %g %g]", gravity.X(), gravity.Y(), gravity.Z());
 
   // get Acceleration and Angular Rates
   // the result of GetRelativeLinearAccel() seems to be unreliable (sum of forces added during the current simulation step)?
   //accel = myBody->GetRelativeLinearAccel(); // get acceleration in body frame
-  math::Vector3 temp = link->GetWorldLinearVel(); // get velocity in world frame
+  ignition::math::Vector3d temp = link->WorldLinearVel(); // get velocity in world frame
   if (dt > 0.0) accel = rot.RotateVectorReverse((temp - velocity) / dt - gravity);
   velocity = temp;
 
   // calculate angular velocity from delta quaternion
   // note: link->GetRelativeAngularVel() sometimes return nan?
   // rate  = link->GetRelativeAngularVel(); // get angular rate in body frame
-  math::Quaternion delta = this->orientation.GetInverse() * rot;
+  ignition::math::Quaterniond delta = this->orientation.Inverse() * rot;
   this->orientation = rot;
   if (dt > 0.0) {
-    rate = this->offset_.rot.GetInverse()
-           * (2.0 * acos(std::max(std::min(delta.w, 1.0), -1.0)) * math::Vector3(delta.x, delta.y, delta.z).Normalize() / dt);
+    rate = this->offset_.Rot().Inverse()
+           * (2.0 * acos(std::max(std::min(delta.W(), 1.0), -1.0)) * ignition::math::Vector3d(delta.X(), delta.Y(), delta.Z()).Normalize() / dt);
   }
 
   // update sensor models
@@ -278,21 +283,21 @@ void GazeboRosIMU::Update()
   rate  = rateModel(rate, dt);
   yawModel.update(dt);
   ROS_DEBUG_NAMED("gazebo_ros_imu", "Current bias errors: accel = [%g %g %g], rate = [%g %g %g], yaw = %g",
-                 accelModel.getCurrentBias().x, accelModel.getCurrentBias().y, accelModel.getCurrentBias().z,
-                 rateModel.getCurrentBias().x, rateModel.getCurrentBias().y, rateModel.getCurrentBias().z,
+                 accelModel.getCurrentBias().X(), accelModel.getCurrentBias().Y(), accelModel.getCurrentBias().Z(),
+                 rateModel.getCurrentBias().X(), rateModel.getCurrentBias().Y(), rateModel.getCurrentBias().Z(),
                  yawModel.getCurrentBias());
   ROS_DEBUG_NAMED("gazebo_ros_imu", "Scale errors: accel = [%g %g %g], rate = [%g %g %g], yaw = %g",
-                 accelModel.getScaleError().x, accelModel.getScaleError().y, accelModel.getScaleError().z,
-                 rateModel.getScaleError().x, rateModel.getScaleError().y, rateModel.getScaleError().z,
+                 accelModel.getScaleError().X(), accelModel.getScaleError().Y(), accelModel.getScaleError().Z(),
+                 rateModel.getScaleError().X(), rateModel.getScaleError().Y(), rateModel.getScaleError().Z(),
                  yawModel.getScaleError());
 
 
   // apply accelerometer and yaw drift error to orientation (pseudo AHRS)
-  math::Vector3 accelDrift = pose.rot.RotateVector(accelModel.getCurrentBias());
+  ignition::math::Vector3d accelDrift = pose.Rot().RotateVector(accelModel.getCurrentBias());
   double yawError = yawModel.getCurrentBias();
-  math::Quaternion orientationError(
-    math::Quaternion(cos(yawError/2), 0.0, 0.0, sin(yawError/2)) *                                         // yaw error
-    math::Quaternion(1.0, 0.5 * accelDrift.y / gravity_length, 0.5 * -accelDrift.x / gravity_length, 0.0)  // roll and pitch error
+  ignition::math::Quaterniond orientationError(
+    ignition::math::Quaterniond(cos(yawError/2), 0.0, 0.0, sin(yawError/2)) *                                         // yaw error
+    ignition::math::Quaterniond(1.0, 0.5 * accelDrift.Y() / gravity_length, 0.5 * - accelDrift.X() / gravity_length, 0.0)  // roll and pitch error
   );
   orientationError.Normalize();
   rot = orientationError * rot;
@@ -303,26 +308,26 @@ void GazeboRosIMU::Update()
   imuMsg.header.stamp.nsec = cur_time.nsec;
 
   // orientation quaternion
-  imuMsg.orientation.x = rot.x;
-  imuMsg.orientation.y = rot.y;
-  imuMsg.orientation.z = rot.z;
-  imuMsg.orientation.w = rot.w;
+  imuMsg.orientation.x = rot.X();
+  imuMsg.orientation.y = rot.Y();
+  imuMsg.orientation.z = rot.Z();
+  imuMsg.orientation.w = rot.W();
 
   // pass angular rates
-  imuMsg.angular_velocity.x    = rate.x;
-  imuMsg.angular_velocity.y    = rate.y;
-  imuMsg.angular_velocity.z    = rate.z;
+  imuMsg.angular_velocity.x    = rate.X();
+  imuMsg.angular_velocity.y    = rate.Y();
+  imuMsg.angular_velocity.z    = rate.Z();
 
   // pass accelerations
-  imuMsg.linear_acceleration.x    = accel.x;
-  imuMsg.linear_acceleration.y    = accel.y;
-  imuMsg.linear_acceleration.z    = accel.z;
+  imuMsg.linear_acceleration.x    = accel.X();
+  imuMsg.linear_acceleration.y    = accel.Y();
+  imuMsg.linear_acceleration.z    = accel.Z();
 
   // fill in covariance matrix
   imuMsg.orientation_covariance[8] = yawModel.gaussian_noise*yawModel.gaussian_noise;
   if (gravity_length > 0.0) {
-    imuMsg.orientation_covariance[0] = accelModel.gaussian_noise.x*accelModel.gaussian_noise.x/(gravity_length*gravity_length);
-    imuMsg.orientation_covariance[4] = accelModel.gaussian_noise.y*accelModel.gaussian_noise.y/(gravity_length*gravity_length);
+    imuMsg.orientation_covariance[0] = accelModel.gaussian_noise.X()*accelModel.gaussian_noise.X()/(gravity_length*gravity_length);
+    imuMsg.orientation_covariance[4] = accelModel.gaussian_noise.Y()*accelModel.gaussian_noise.Y()/(gravity_length*gravity_length);
   } else {
     imuMsg.orientation_covariance[0] = -1;
     imuMsg.orientation_covariance[4] = -1;
@@ -335,16 +340,16 @@ void GazeboRosIMU::Update()
   // publish bias
   if (bias_pub_) {
     biasMsg.header = imuMsg.header;
-    biasMsg.orientation.x = orientationError.x;
-    biasMsg.orientation.y = orientationError.y;
-    biasMsg.orientation.z = orientationError.z;
-    biasMsg.orientation.w = orientationError.w;
-    biasMsg.angular_velocity.x = rateModel.getCurrentBias().x;
-    biasMsg.angular_velocity.y = rateModel.getCurrentBias().y;
-    biasMsg.angular_velocity.z = rateModel.getCurrentBias().z;
-    biasMsg.linear_acceleration.x = accelModel.getCurrentBias().x;
-    biasMsg.linear_acceleration.y = accelModel.getCurrentBias().y;
-    biasMsg.linear_acceleration.z = accelModel.getCurrentBias().z;
+    biasMsg.orientation.x = orientationError.X();
+    biasMsg.orientation.y = orientationError.Y();
+    biasMsg.orientation.z = orientationError.Z();
+    biasMsg.orientation.w = orientationError.W();
+    biasMsg.angular_velocity.x = rateModel.getCurrentBias().X();
+    biasMsg.angular_velocity.y = rateModel.getCurrentBias().Y();
+    biasMsg.angular_velocity.z = rateModel.getCurrentBias().Z();
+    biasMsg.linear_acceleration.x = accelModel.getCurrentBias().X();
+    biasMsg.linear_acceleration.y = accelModel.getCurrentBias().Y();
+    biasMsg.linear_acceleration.z = accelModel.getCurrentBias().Z();
     bias_pub_.publish(biasMsg);
   }
 

--- a/hector_gazebo_thermal_camera/src/gazebo_ros_thermal_camera.cpp
+++ b/hector_gazebo_thermal_camera/src/gazebo_ros_thermal_camera.cpp
@@ -123,7 +123,7 @@ void GazeboRosThermalCamera_<Base>::OnNewFrame(const unsigned char *_image,
   {
     if ((*this->image_connect_count_) > 0)
     {
-      common::Time cur_time = this->world_->GetSimTime();
+      common::Time cur_time = this->world_->SimTime();
       if (cur_time - this->last_update_time_ >= this->update_period_)
       {
         this->PutCameraData(_image);


### PR DESCRIPTION
These changes correspond to the gazebo API changes in versions 8/9 (removal of gazebo math library, some changes to events, renaming of some methods).

After making these changes, the gazebo_ros_imu code compiles and I tested that it publishes imu data in ROS. For the rest of the executables (e.g. diff_drive_6w), similar changes are probably necessary to get the whole pkg up to date.