### PR TITLE
add CMP0045 cmake policy before gazebo include in CMakeLists.txt

### DIFF
--- a/hector_gazebo_plugins/CMakeLists.txt
+++ b/hector_gazebo_plugins/CMakeLists.txt
@@ -8,6 +8,9 @@ find_package(catkin REQUIRED COMPONENTS roscpp std_msgs std_srvs geometry_msgs n
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Find gazebo
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
 find_package(gazebo REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 include_directories(${GAZEBO_INCLUDE_DIRS})

--- a/hector_gazebo_thermal_camera/CMakeLists.txt
+++ b/hector_gazebo_thermal_camera/CMakeLists.txt
@@ -8,6 +8,9 @@ find_package(catkin REQUIRED COMPONENTS gazebo_plugins)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Find gazebo
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
 find_package(gazebo REQUIRED)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
 include_directories(${GAZEBO_INCLUDE_DIRS})


### PR DESCRIPTION
This fixes compile time warnings due to the new cmake policy 0054. Only tested on melodic, since I don't have a working kinetic-setup. Since this was introduced with cmake 3.1 it should work on Ubuntu 16.04 though.