### PR TITLE
Add support of holonomic robot by adding missing Y component in odometry

### DIFF
--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_force_based_move.h
@@ -59,7 +59,7 @@ namespace gazebo {
     private:
       void publishOdometry(double step_time);
 
-      tf::Transform getTransformForMotion(double linear_vel_x, double angular_vel, double timeSeconds) const;
+      tf::Transform getTransformForMotion(double linear_vel_x, double linear_vel_y, double angular_vel, double timeSeconds) const;
 
       physics::ModelPtr parent_;
       event::ConnectionPtr update_connection_;

--- a/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
@@ -374,18 +374,18 @@ namespace gazebo
       const double distX = linear_vel_x * timeSeconds;
       const double distY = linear_vel_y * timeSeconds;
       const double distChange = std::sqrt(distX * distX + distY * distY);
-      const double angleDist = std::acos(distX / distChange);
-      const double angleDriveDirection = angular_vel * timeSeconds;
+      const double angleDriveDirection = std::acos(distX / distChange);
+      const double angleChange = angular_vel * timeSeconds;
 
-      const double arcRadius = distChange / angleDriveDirection;
+      const double arcRadius = distChange / angleChange;
 
-      tf::Vector3 endPos = tf::Vector3(std::sin(angleDriveDirection) * arcRadius,
-                                arcRadius - std::cos(angleDriveDirection) * arcRadius,
+      tf::Vector3 endPos = tf::Vector3(std::sin(angleChange) * arcRadius,
+                                arcRadius - std::cos(angleChange) * arcRadius,
                                 0.0);
 
-      tmp.setOrigin(endPos.rotate(tf::Vector3(0.0, 0.0, 1.0), angleDist));
+      tmp.setOrigin(endPos.rotate(tf::Vector3(0.0, 0.0, 1.0), angleDriveDirection));
 
-      tmp.setRotation(tf::createQuaternionFromYaw(angleDriveDirection));
+      tmp.setRotation(tf::createQuaternionFromYaw(angleChange));
     }
 
     return tmp;

--- a/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_force_based_move.cpp
@@ -375,17 +375,17 @@ namespace gazebo
       const double distY = linear_vel_y * timeSeconds;
       const double distChange = std::sqrt(distX * distX + distY * distY);
       const double angleDist = std::acos(distX / distChange);
-      const double angleChange = angular_vel * timeSeconds;
+      const double angleDriveDirection = angular_vel * timeSeconds;
 
-      const double arcRadius = distChange / angleChange;
+      const double arcRadius = distChange / angleDriveDirection;
 
-      tf::Vector3 endPos = tf::Vector3(std::sin(angleChange) * arcRadius,
-                                arcRadius - std::cos(angleChange) * arcRadius,
+      tf::Vector3 endPos = tf::Vector3(std::sin(angleDriveDirection) * arcRadius,
+                                arcRadius - std::cos(angleDriveDirection) * arcRadius,
                                 0.0);
 
       tmp.setOrigin(endPos.rotate(tf::Vector3(0.0, 0.0, 1.0), angleDist));
 
-      tmp.setRotation(tf::createQuaternionFromYaw(angleChange));
+      tmp.setRotation(tf::createQuaternionFromYaw(angleDriveDirection));
     }
 
     return tmp;


### PR DESCRIPTION
I used the force based move plugin to simulate holonomic robots and I noticed the published odometry was only taking in account the linear velocity on the x-axis and the angular velocity around the z-axis.

I'm proposing here a way to add the linear y-axis velocity to the odometry calculations. I'm aware of the previous PR on the subject (https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/pull/31/commits/6de5644bdb9999e2e190db2973918585948b8137) but I believe my method is more accurate as I still use the arc method.

Arc and radius are calculated the same way as before but using the combined linear velocity instead. The end position is then rotated by the angle between the combined velocity vector and the x-axis

One concern would be that being able to measure the linear velocity on the y-axis might not make sense for non-holonomic robot  Maybe having this y-axis linear velocity as an option tag could be a good idea.