### PR TITLE
[fix] Fixing the namespacing for the sonar plugin

### DIFF
--- a/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
@@ -35,6 +35,8 @@
 
 #include <gazebo/gazebo_config.h>
 
+#include <boost/algorithm/string.hpp>
+
 namespace gazebo {
 
 GazeboRosSonar::GazeboRosSonar()
@@ -86,6 +88,18 @@ void GazeboRosSonar::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
   // load parameters
   if (_sdf->HasElement("robotNamespace"))
     namespace_ = _sdf->GetElement("robotNamespace")->GetValue()->GetAsString();
+
+  if (namespace_ == "/"){
+    std::vector<std::string> values;
+    std::string scopedName = _sensor->ScopedName();
+    boost::replace_all ( scopedName, "::", ",");
+    boost::split ( values, scopedName, boost::is_any_of (","));
+    if ( values.size()<2){
+      namespace_ = "";
+    } else {
+      namespace_ = values[1];
+    }
+  }
 
   if (_sdf->HasElement("frameId"))
     frame_id_ = _sdf->GetElement("frameId")->GetValue()->GetAsString();

--- a/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
@@ -86,8 +86,7 @@ void GazeboRosSonar::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
   frame_id_ = "/sonar_link";
 
   // load parameters
- if (_sdf->HasElement("useNamespaceFromScopedName")){
-     if (_sdf->GetElement("useNamespaceFromScopedName")){
+ if (_sdf->HasElement("useNamespaceFromScopedName") && _sdf->GetElement("useNamespaceFromScopedName")){
     	 std::vector<std::string> values;
     	 std::string scopedName = _sensor->ScopedName();
     	 boost::replace_all ( scopedName, "::", ",");
@@ -98,7 +97,8 @@ void GazeboRosSonar::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
     	   namespace_ = values[1];
    	 }
      }
-   }else if (_sdf->HasElement("robotNamespace")){
+   
+ if (_sdf->HasElement("robotNamespace")){
 	namespace_ = _sdf->GetElement("robotNamespace")->GetValue()->GetAsString();
    }
 

--- a/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_sonar.cpp
@@ -86,20 +86,22 @@ void GazeboRosSonar::Load(sensors::SensorPtr _sensor, sdf::ElementPtr _sdf)
   frame_id_ = "/sonar_link";
 
   // load parameters
-  if (_sdf->HasElement("robotNamespace"))
-    namespace_ = _sdf->GetElement("robotNamespace")->GetValue()->GetAsString();
+ if (_sdf->HasElement("useNamespaceFromScopedName")){
+     if (_sdf->GetElement("useNamespaceFromScopedName")){
+    	 std::vector<std::string> values;
+    	 std::string scopedName = _sensor->ScopedName();
+    	 boost::replace_all ( scopedName, "::", ",");
+    	 boost::split ( values, scopedName, boost::is_any_of (","));
+    	 if ( values.size()<2){
+    	   namespace_ = "";
+    	 } else {
+    	   namespace_ = values[1];
+   	 }
+     }
+   }else if (_sdf->HasElement("robotNamespace")){
+	namespace_ = _sdf->GetElement("robotNamespace")->GetValue()->GetAsString();
+   }
 
-  if (namespace_ == "/"){
-    std::vector<std::string> values;
-    std::string scopedName = _sensor->ScopedName();
-    boost::replace_all ( scopedName, "::", ",");
-    boost::split ( values, scopedName, boost::is_any_of (","));
-    if ( values.size()<2){
-      namespace_ = "";
-    } else {
-      namespace_ = values[1];
-    }
-  }
 
   if (_sdf->HasElement("frameId"))
     frame_id_ = _sdf->GetElement("frameId")->GetValue()->GetAsString();


### PR DESCRIPTION
### Namespacing for sonar plugin
While using the `gazebo_ros_sonar `plugin in a drone URDF model and spawning this type of drone several times in my`.world` with different robot namespaces, I encountered that type of error, since the same namespacing is used for all sonars on all drones: 
`[ERROR] [1598280399.141939871, 74.990000000]: Tried to advertise a service that is already advertised in this node [/sonar_front_center_015/range/set_parameters]`
I offer here a solution which is highly inspired by the methods `GetModelName` and `GetRobotNamespace` from [gazebo_ros_utils.h](http://docs.ros.org/hydro/api/gazebo_plugins/html/gazebo__ros__utils_8h_source.html). Those two methods are used in the `gazebo_ros_camera `plugin and allow several robots from the same model to have their own sensors with their own topics. 

