### PR TITLE
Add parameter to enable fetching the spherical coordinates from the world.

### DIFF
--- a/hector_gazebo_plugins/src/gazebo_ros_gps.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_gps.cpp
@@ -88,7 +88,7 @@ void GazeboRosGps::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   fix_topic_ = "fix";
   velocity_topic_ = "fix_velocity";
 
-  common::SphericalCoordinatesPtr spherical_coords = world->GetSphericalCoordinates();
+  common::SphericalCoordinatesPtr spherical_coords = world->SphericalCoords();
   reference_latitude_ = spherical_coords->LatitudeReference().Degree();
   reference_longitude_ = spherical_coords->LongitudeReference().Degree();
   // SDF specifies heading counter-clockwise from east, but here it's measured clockwise from north

--- a/hector_gazebo_plugins/src/gazebo_ros_magnetic.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_magnetic.cpp
@@ -32,6 +32,7 @@
 #include <gazebo/physics/physics.hh>
 
 static const double DEFAULT_MAGNITUDE           = 1.0;
+static const double DEFAULT_REFERENCE_HEADING   = 0.0;
 static const double DEFAULT_DECLINATION         = 0.0;
 static const double DEFAULT_INCLINATION         = 60.0;
 
@@ -88,15 +89,23 @@ void GazeboRosMagnetic::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     return;
   }
 
-  common::SphericalCoordinatesPtr spherical_coords = world->SphericalCoords();
-
   // default parameters
   frame_id_ = link_name_;
   magnitude_ = DEFAULT_MAGNITUDE;
-  // SDF specifies heading counter-clockwise from east, but here it's measured clockwise from north
-  reference_heading_ = (M_PI / 2.0) - spherical_coords->HeadingOffset().Radian();
+  reference_heading_ = DEFAULT_REFERENCE_HEADING * M_PI/180.0;
   declination_ = DEFAULT_DECLINATION * M_PI/180.0;
   inclination_ = DEFAULT_INCLINATION * M_PI/180.0;
+
+  if (_sdf->HasElement("useWorldSphericalCoordinates"))
+  {
+    bool use_world_coords = false;
+    if (_sdf->GetElement("useWorldSphericalCoordinates")->GetValue()->Get(use_world_coords) && use_world_coords)
+    {
+      common::SphericalCoordinatesPtr spherical_coords = world->SphericalCoords();
+      // SDF specifies heading counter-clockwise from east, but here it's measured clockwise from north
+      reference_heading_ = (M_PI / 2.0) - spherical_coords->HeadingOffset().Radian();
+    }
+  }
 
   if (_sdf->HasElement("frameId"))
     frame_id_ = _sdf->GetElement("frameId")->GetValue()->GetAsString();

--- a/hector_gazebo_plugins/src/gazebo_ros_magnetic.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_magnetic.cpp
@@ -28,10 +28,10 @@
 
 #include <hector_gazebo_plugins/gazebo_ros_magnetic.h>
 #include <gazebo/common/Events.hh>
+#include <gazebo/common/SphericalCoordinates.hh>
 #include <gazebo/physics/physics.hh>
 
 static const double DEFAULT_MAGNITUDE           = 1.0;
-static const double DEFAULT_REFERENCE_HEADING   = 0.0;
 static const double DEFAULT_DECLINATION         = 0.0;
 static const double DEFAULT_INCLINATION         = 60.0;
 
@@ -88,10 +88,13 @@ void GazeboRosMagnetic::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     return;
   }
 
+  common::SphericalCoordinatesPtr spherical_coords = world->GetSphericalCoordinates();
+
   // default parameters
   frame_id_ = link_name_;
   magnitude_ = DEFAULT_MAGNITUDE;
-  reference_heading_ = DEFAULT_REFERENCE_HEADING * M_PI/180.0;
+  // SDF specifies heading counter-clockwise from east, but here it's measured clockwise from north
+  reference_heading_ = (M_PI / 2.0) - spherical_coords->HeadingOffset().Radian();
   declination_ = DEFAULT_DECLINATION * M_PI/180.0;
   inclination_ = DEFAULT_INCLINATION * M_PI/180.0;
 

--- a/hector_gazebo_plugins/src/gazebo_ros_magnetic.cpp
+++ b/hector_gazebo_plugins/src/gazebo_ros_magnetic.cpp
@@ -88,7 +88,7 @@ void GazeboRosMagnetic::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     return;
   }
 
-  common::SphericalCoordinatesPtr spherical_coords = world->GetSphericalCoordinates();
+  common::SphericalCoordinatesPtr spherical_coords = world->SphericalCoords();
 
   // default parameters
   frame_id_ = link_name_;


### PR DESCRIPTION
This extends #47 with the addition of a "useWorldSphericalCoordinates" parameter
that must be present and set to true to allow using the world's coordinates.

This should solve #15 while addressing the concerns in #47.
