### PR TITLE
Add service to gazebo gps sensor to set reference geopose

### DIFF
--- a/hector_gazebo_plugins/CMakeLists.txt
+++ b/hector_gazebo_plugins/CMakeLists.txt
@@ -4,7 +4,7 @@ project(hector_gazebo_plugins VERSION 0.5.3)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp std_msgs std_srvs geometry_msgs nav_msgs tf dynamic_reconfigure message_generation)
+find_package(catkin REQUIRED COMPONENTS roscpp std_msgs std_srvs geographic_msgs geometry_msgs nav_msgs tf dynamic_reconfigure message_generation)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Find gazebo
@@ -30,14 +30,15 @@ include_directories(${Boost_INCLUDE_DIRS})
 # )
 
 ## Generate services in the 'srv' folder
-add_service_files(
+add_service_files(DIRECTORY srv
   FILES
-  SetBias.srv
+    SetBias.srv
+    SetReferenceGeoPose.srv
 )
 
 ## Generate added messages and services with any dependencies listed here
 generate_messages(
-  DEPENDENCIES geometry_msgs
+  DEPENDENCIES geographic_msgs geometry_msgs
 )
 
 #add dynamic reconfigure api
@@ -56,7 +57,7 @@ generate_dynamic_reconfigure_options(
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    CATKIN_DEPENDS roscpp std_msgs geometry_msgs nav_msgs tf message_runtime
+    CATKIN_DEPENDS roscpp std_msgs geographic_msgs geometry_msgs nav_msgs tf message_runtime
     INCLUDE_DIRS include
     LIBRARIES
 )

--- a/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_gps.h
+++ b/hector_gazebo_plugins/include/hector_gazebo_plugins/gazebo_ros_gps.h
@@ -34,8 +34,10 @@
 #include <ros/ros.h>
 #include <sensor_msgs/NavSatFix.h>
 #include <geometry_msgs/Vector3Stamped.h>
+#include <hector_gazebo_plugins/SetReferenceGeoPose.h>
 #include <hector_gazebo_plugins/sensor_model.h>
 #include <hector_gazebo_plugins/update_timer.h>
+#include <tf/tf.h>
 
 #include <dynamic_reconfigure/server.h>
 #include <hector_gazebo_plugins/GNSSConfig.h>
@@ -58,6 +60,11 @@ protected:
   void dynamicReconfigureCallback(GNSSConfig &config, uint32_t level);
 
 private:
+
+  /// \brief Callback for the set_spherical_coordinates service
+  bool setGeoposeCb(hector_gazebo_plugins::SetReferenceGeoPose::Request& request,
+                    hector_gazebo_plugins::SetReferenceGeoPose::Response&);
+
   /// \brief The parent World
   physics::WorldPtr world;
 
@@ -67,6 +74,8 @@ private:
   ros::NodeHandle* node_handle_;
   ros::Publisher fix_publisher_;
   ros::Publisher velocity_publisher_;
+
+  ros::ServiceServer set_geopose_srv_;
 
   sensor_msgs::NavSatFix fix_;
   geometry_msgs::Vector3Stamped velocity_;

--- a/hector_gazebo_plugins/package.xml
+++ b/hector_gazebo_plugins/package.xml
@@ -22,6 +22,7 @@
   <!-- Dependencies needed to compile this package. -->
   <build_depend>roscpp</build_depend>
   <build_depend>gazebo_dev</build_depend>
+  <build_depend>geographic_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -34,6 +35,7 @@
   <exec_depend>roscpp</exec_depend>
   <exec_depend>gazebo</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>geographic_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/hector_gazebo_plugins/srv/SetReferenceGeoPose.srv
+++ b/hector_gazebo_plugins/srv/SetReferenceGeoPose.srv
@@ -1,0 +1,2 @@
+geographic_msgs/GeoPose geo_pose
+---


### PR DESCRIPTION
This PR implements a set_reference_geopose service for the gazebo_ros_gps plugin.

Similar to the SetDatum service in robot localization's navsat_transform node, it allows for changing the geographic reference pose.

We found this especially useful in simulations that need resets on new tasks for example, or simulation that travel far from the origin. But also for simulations to set this from the ROS framework, instead of hard-coding it in xml's.