### PR TITLE
Fix #88 gazebo_ros_gps dependencies

### DIFF
--- a/hector_gazebo_plugins/CMakeLists.txt
+++ b/hector_gazebo_plugins/CMakeLists.txt
@@ -88,7 +88,7 @@ add_dependencies(hector_gazebo_ros_magnetic ${PROJECT_NAME}_gencfg)
 
 add_library(hector_gazebo_ros_gps src/gazebo_ros_gps.cpp)
 target_link_libraries(hector_gazebo_ros_gps ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
-add_dependencies(hector_gazebo_ros_gps ${PROJECT_NAME}_gencfg)
+add_dependencies(hector_gazebo_ros_gps ${PROJECT_NAME}_generate_messages_cpp ${PROJECT_NAME}_gencfg)
 
 add_library(hector_gazebo_ros_sonar src/gazebo_ros_sonar.cpp)
 target_link_libraries(hector_gazebo_ros_sonar ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})


### PR DESCRIPTION
* Detail
  - Failed `catkin build` after `catkin clean` because of lack of generate_message_cpp dependency
* Change files
  - modified:   hector_gazebo_plugins/CMakeLists.txt
 * fix #88 .