### PR TITLE
Fix hector_gazebo_plugins building as .a files in some environments

### DIFF
--- a/hector_gazebo_plugins/CMakeLists.txt
+++ b/hector_gazebo_plugins/CMakeLists.txt
@@ -75,41 +75,41 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
 set(HECTOR_GAZEBO_ROS_PLUGINS_LIST "")
 
-# add_library(diffdrive_plugin_6w src/diffdrive_plugin_6w.cpp)
+# add_library(diffdrive_plugin_6w SHARED src/diffdrive_plugin_6w.cpp)
 # target_link_libraries(diffdrive_plugin_6w ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
-# add_library(diffdrive_plugin_multi_wheel src/diffdrive_plugin_multi_wheel.cpp)
+# add_library(diffdrive_plugin_multi_wheel SHARED src/diffdrive_plugin_multi_wheel.cpp)
 # target_link_libraries(diffdrive_plugin_multi_wheel ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
-# add_library(gazebo_ros_force_based_move src/gazebo_ros_force_based_move.cpp)
+# add_library(gazebo_ros_force_based_move SHARED src/gazebo_ros_force_based_move.cpp)
 # target_link_libraries(gazebo_ros_force_based_move ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
-add_library(hector_gazebo_reset_plugin src/reset_plugin.cpp)
+add_library(hector_gazebo_reset_plugin SHARED src/reset_plugin.cpp)
 target_link_libraries(hector_gazebo_reset_plugin ${GAZEBO_LIBRARIES})
 list(APPEND HECTOR_GAZEBO_ROS_PLUGINS_LIST hector_gazebo_reset_plugin)
 ament_target_dependencies(hector_gazebo_reset_plugin ${LIBS})
 
-add_library(hector_gazebo_ros_imu src/gazebo_ros_imu.cpp)
+add_library(hector_gazebo_ros_imu SHARED src/gazebo_ros_imu.cpp)
 target_link_libraries(hector_gazebo_ros_imu ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES})
 list(APPEND HECTOR_GAZEBO_ROS_PLUGINS_LIST hector_gazebo_ros_imu)
 ament_target_dependencies(hector_gazebo_ros_imu ${LIBS})
 
-add_library(hector_gazebo_ros_magnetic src/gazebo_ros_magnetic.cpp)
+add_library(hector_gazebo_ros_magnetic SHARED src/gazebo_ros_magnetic.cpp)
 target_link_libraries(hector_gazebo_ros_magnetic ${GAZEBO_LIBRARIES})
 list(APPEND HECTOR_GAZEBO_ROS_PLUGINS_LIST hector_gazebo_ros_magnetic)
 ament_target_dependencies(hector_gazebo_ros_magnetic ${LIBS})
 
-add_library(hector_gazebo_ros_gps src/gazebo_ros_gps.cpp)
+add_library(hector_gazebo_ros_gps SHARED src/gazebo_ros_gps.cpp)
 target_link_libraries(hector_gazebo_ros_gps ${GAZEBO_LIBRARIES})
 list(APPEND HECTOR_GAZEBO_ROS_PLUGINS_LIST hector_gazebo_ros_gps)
 ament_target_dependencies(hector_gazebo_ros_gps ${LIBS})
 
-add_library(hector_gazebo_ros_sonar src/gazebo_ros_sonar.cpp)
+add_library(hector_gazebo_ros_sonar SHARED src/gazebo_ros_sonar.cpp)
 target_link_libraries(hector_gazebo_ros_sonar ${GAZEBO_LIBRARIES})
 list(APPEND HECTOR_GAZEBO_ROS_PLUGINS_LIST hector_gazebo_ros_sonar)
 ament_target_dependencies(hector_gazebo_ros_sonar ${LIBS})
 
-# add_library(hector_servo_plugin src/servo_plugin.cpp)
+# add_library(hector_servo_plugin SHARED src/servo_plugin.cpp)
 # target_link_libraries(hector_servo_plugin ${Boost_LIBRARIES} ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES})
 
 


### PR DESCRIPTION
Addresses issue mentioned in https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/issues/93#issuecomment-1204832970 by building plugins explicitly as shared libraries.

Tested that issue is present in image [here](https://hub.docker.com/layers/ros/library/ros/galactic/images/sha256-26b0b7d49c3e9fa792a6d7831b98aa6b1bb5add16002f347e5f8a165c3e30f0a?context=explore). I.e. plugins are built as .a files.
After the changes in this PR, they build as .so files.
The changes are also tested to work by being able to use the data from GPS plugin.